### PR TITLE
Remove unused imports in setup.py that cause ModuleNotFound error when installing spotipy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import, print_function
-from setuptools import setup, find_packages, Extension
-from setuptools.command.build_ext import build_ext
-from numpy.distutils.misc_util import get_numpy_include_dirs
-from os import path
-#------------------------------------------------------------------------------------
+
+from setuptools import setup, find_packages
 
 setup(
     name='spotipy',
@@ -34,7 +31,6 @@ setup(
         'scikit-image',
         'csbdeep',
         'stardist',
-        # 'opencv-python'
     ],
 
 )


### PR DESCRIPTION
There is an unused numpy import before the the install_requires that throws an error. I suggest to clean the unused import from setup.py